### PR TITLE
AuthLoginResponse Error message fix

### DIFF
--- a/ow.Framework/Game/Enums/AuthLoginErrorMessageCode.cs
+++ b/ow.Framework/Game/Enums/AuthLoginErrorMessageCode.cs
@@ -6,13 +6,8 @@
     public enum AuthLoginErrorMessageCode : uint
     {
         None,
-        LoginFailed = 50104,
-        WrongUsernameOrPassword = 50105,
-        TheIdYouEnteredIsAlreadyConnectedToTheServer = 50106,
-        AccountIsBlocked = 50109,
-        IpIsBlocked = 50110,
-
-        /// Forgot ID
-        // MacIsBlocked = 50110
+        WrongUsernameOrPassword = 1,
+        TheIdYouEnteredIsAlreadyConnectedToTheServer = 2,
+        WithErrorMessage = 3
     }
 }

--- a/ow.Framework/IO/Network/GameSession.cs
+++ b/ow.Framework/IO/Network/GameSession.cs
@@ -321,17 +321,16 @@ namespace ow.Framework.IO.Network
             {
                 writer.Write(value.AccountId);
 
-                writer.WriteAuthLoginStatus(value.Response);
-                writer.Write(Encoding.ASCII.GetBytes(value.Mac));
-
                 writer.Write(byte.MinValue);
-                writer.WriteByteLengthUnicodeString(string.Empty);
+
+                writer.Write(value.Response == AuthLoginStatus.Failure ? new byte[18] : Encoding.ASCII.GetBytes(value.Mac));
+
+                writer.WriteByteLengthUnicodeString(value.ErrorMessage);
                 writer.WriteAuthLoginErrorMessageCode(value.ErrorMessageCode);
+                writer.Write(byte.MinValue);
+                writer.WriteByteLengthUnicodeString(value.ErrorMessage);
+                writer.Write(value.Response == AuthLoginStatus.Failure ? 0 : value.SessionKey);
 
-                writer.Write((byte)1);
-                writer.WriteByteLengthUnicodeString("134006893");
-
-                writer.Write(value.SessionKey);
                 writer.Write(byte.MinValue);
                 writer.Write(uint.MinValue);
                 writer.Write(byte.MinValue);

--- a/ow.Service.Login/Network/Handlers/ServiceHandler.cs
+++ b/ow.Service.Login/Network/Handlers/ServiceHandler.cs
@@ -32,7 +32,6 @@ namespace ow.Service.Login.Network.Handlers
             }
             else
             {
-                // TODO: Not work. Message doesn't show.
                 session.SendAsync(new AuthLoginResponse
                 {
                     Response = AuthLoginStatus.Failure,


### PR DESCRIPTION
Fixed an error where AuthLoginResponse did not send an error message

Login Fail:
![비밀번호틀림2](https://user-images.githubusercontent.com/59918240/103149759-d991ec00-47af-11eb-863a-21fde657f4d4.gif)

Login Success:
![로그인성공2](https://user-images.githubusercontent.com/59918240/103149765-e4e51780-47af-11eb-8f08-a000a1540577.gif)
